### PR TITLE
Add support for older Bash versions.

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -33,7 +33,7 @@ while (( $# > 0 )); do
     ;;
   esac
 done
-set -- "${new_args[@]}"
+set -- ${new_args[@]+"${new_args[@]}"}
 unset new_args
 if [[ ${debug-no} == yes ]]; then
   set -x


### PR DESCRIPTION
bin/common.sh: On Bash 4.3 or older, expansion of an empty array
               results in an error. This commit adds support for such
               an old Bash.