### PR TITLE
Tweak `gcc/install`.

### DIFF
--- a/gcc/install
+++ b/gcc/install
@@ -19,11 +19,10 @@ Install GCC.
 
   --version=<VERSION>        The version of GCC to install (default: the
                              latest release version).
-  --prefix=<DIR>             Pass `--prefix=<DIR>' on to GCC `configure'
-                             script.
-  --source-dir=<DIR>         The source directory (default: a temporary
-                             directory that will be deleted when this script
-                             exits).
+  --prefix=<PREFIX>          Pass `--prefix=<PREFIX>' on to GCC `configure'
+                             script (default: `/usr/local').
+  --source-dir=<DIR>         The source directory (default:
+                             `<PREFIX>/src/gcc').
   --clobber-source-dir       Delete the source directory before the source
                              archive is expanded there.
   -h, --help                 Display this help and exit.
@@ -33,17 +32,12 @@ EOF
 if getopt -T; (( $? != 4 )); then
   die_with_runtime_error "$PROGRAM_NAME" "\`getopt' is not an enhanced version."
 fi
-
 opts="$(getopt -n "$PROGRAM_NAME" -l version:,prefix:,source-dir:,clobber-source-dir,help -- h "$@")"
 eval set -- "$opts"
 
-expect_rest_args=no
 while (( $# > 0 )); do
   arg="$1"
   shift
-  if [[ $expect_rest_args == yes ]]; then
-    die_with_user_error "$PROGRAM_NAME" "An invalid argument \`$arg'."
-  fi
   case "$arg" in
   --version)
     if (( $# == 0 )); then
@@ -75,52 +69,55 @@ while (( $# > 0 )); do
     exit 0
     ;;
   --)
-    expect_rest_args=yes
+    if (( $# > 0 )); then
+      die_with_user_error "$PROGRAM_NAME" "An invalid argument \`$1'."
+    fi
+    break
     ;;
   *)
     die_with_user_error "$PROGRAM_NAME" "An invalid argument \`$arg'."
     ;;
   esac
 done
-unset expect_rest_args
 
 configure_options=()
 
 if [[ ${version-NOT-DEFINED} == NOT-DEFINED ]]; then
-  version="$({ curl -fLsS "$URL_PREFIX" || exit $?; }                                                            \
-               | { grep -Eo 'gcc-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/' || exit $?; }                        \
-               | { sed -e 's@gcc-\([[:digit:]]\{1,\}\.[[:digit:]]\{1,\}\.[[:digit:]]\{1,\}\)/@\1@' || exit $?; } \
-               | { sort -V || exit $?; }                                                                         \
-               | tail -n 1)" || status=$?
-  if (( "${status-0}" != 0 )) || [[ ! $version =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]; then
-    die_with_runtime_error "$PROGRAM_NAME" "Failed to extract GCC latest version."
+  version="$(curl -fLsS "$URL_PREFIX"                                     \
+               | grep -Eo 'gcc-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/' \
+               | grep -Eo '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+'      \
+               | sort -V                                                  \
+               | tail -n 1)" \
+    || die_with_runtime_error "$PROGRAM_NAME" "Failed to guess GCC latest version."
+  if [[ ! $version =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]; then
+    die_with_runtime_error "$PROGRAM_NAME" "Failed to guess GCC latest version."
   fi
 fi
 if [[ ! $version =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]; then
   die_with_user_error "$PROGRAM_NAME" "An invalid value \`$version' for \`--version' option."
 fi
 
-if [[ ${prefix+DEFINED} == DEFINED ]]; then
-  configure_options+=("--prefix=$prefix")
+if [[ ${prefix-NOT-DEFINED} == NOT-DEFINED ]]; then
+  prefix=/usr/local
 fi
+configure_options+=("--prefix=$prefix")
 
 temp_dir="$(mktemp -d)" \
-  || die_with_runtime_error "Failed to create a temporary directory."
-
+  || die_with_runtime_error "$PROGRAM_NAME" "Failed to create a temporary directory."
 push_rollback_command "rm -rf \"$temp_dir\""
 
-: "${source_dir=$temp_dir/src}"
+if [[ ${source_dir-NOT-DEFINED} == NOT-DEFINED ]]; then
+  source_dir="$prefix/src/gcc"
+fi
 if [[ -z $source_dir ]]; then
   die_with_user_error "$PROGRAM_NAME" "An invalid value \`$source_dir' for \`--source-dir' option."
 fi
 if [[ $(readlink -m "$source_dir") != $(cd "$temp_dir" >/dev/null && readlink -m "$source_dir") ]]; then
-  die_with_user_error "$PROGRAM_NAME" "A relative path \`$source_dir' for \`--source-dir' option, but is expected to be an absolute one."
+  die_with_user_error "$PROGRAM_NAME" "A relative path \`$source_dir' is specified for \`--source-dir' option, but is expected to be an absolute one."
 fi
 
-: "${clobber_source_dir=no}"
-
 if [[ -e $source_dir ]]; then
-  case "$clobber_source_dir" in
+  case "${clobber_source_dir-no}" in
   yes)
     rm -rf "$source_dir"
     ;;
@@ -173,12 +170,23 @@ rm "$temp_dir/gcc-$version.tar.xz"
 rm "$source_dir"/*.tar.*
 
 build_dir="$temp_dir/build"
-mkdir -p "$build_dir"
+mkdir "$build_dir"
 
-(cd "$build_dir" && "$source_dir/configure" --disable-multilib --enable-languages=c,c++ "${configure_options[@]}") \
+(cd "$build_dir"
+ "$source_dir/configure"                             \
+   --disable-multilib                                \
+   --enable-languages=c,c++                          \
+   ${configure_options[@]+"${configure_options[@]}"}) \
   || die_with_runtime_error "$PROGRAM_NAME" "Failed to \`configure' GCC."
 
-(cd "$build_dir" && make -j $(nproc) ) \
+make_options=()
+
+# Check whether this script is (directly or indirectly) called from `make'.
+if ! declare -p MAKEFLAGS 2>/dev/null | grep -Eq '^declare -x MAKEFLAGS='; then
+  make_options+=(-j -l "$(nproc)")
+fi
+
+(cd "$build_dir" && make ${make_options[@]+"${make_options[@]}"}) \
   || die_with_runtime_error "$PROGRAM_NAME" "Failed to \`make' GCC."
 
 (cd "$build_dir" && make install-strip) \


### PR DESCRIPTION
- `gcc/install`:
  - The default value for `--prefix` option is set to `/usr/local`.
  - The default value for `--source-dir` option is changed to
    `<PREFIX>/src/gcc`.
  - Do not set `-j` option for `make` if `gcc/install` is (directly or
    indirectly) called from `make`.