### PR TITLE
Fix a bug in `icu4c/configure`

### DIFF
--- a/cmake/install
+++ b/cmake/install
@@ -145,13 +145,13 @@ done
 tarball_basename="cmake-$version"
 tarball_name="$tarball_basename.tar.gz"
 
-(cd "$temp_dir"
+(cd "$temp_dir" || exit $?;
  curl -fLsSo "$tarball_name" "https://cmake.org/files/LatestRelease/$tarball_name") \
   || die_with_runtime_error "$PROGRAM_NAME" "Failed to download \`$tarball_name'."
-(cd "$temp_dir"
+(cd "$temp_dir" || exit $?;
  curl -fLsSo "$tarball_basename-SHA-256.txt" "https://cmake.org/files/LatestRelease/$tarball_basename-SHA-256.txt") \
   || die_with_runtime_error "$PROGRAM_NAME" "Failed to download \`$tarball_basename-SHA-256.txt'."
-(cd "$temp_dir"
+(cd "$temp_dir" || exit $?;
  curl -fLsSo "$tarball_basename-SHA-256.txt.asc" "https://cmake.org/files/LatestRelease/$tarball_basename-SHA-256.txt.asc") \
   || die_with_runtime_error "$PROGRAM_NAME" "Failed to download \`$tarball_basename-SHA-256.txt.asc'."
 
@@ -164,7 +164,7 @@ gpg                                             \
   || die_with_runtime_error "$PROGRAM_NAME" "Failed to verify the signature in \`$tarball_basename-SHA-256.txt.asc'."
 rm "$temp_dir/$tarball_basename-SHA-256.txt.asc"
 
-(cd "$temp_dir"
+(cd "$temp_dir" || exit $?;
  grep -E "[[:space:]]$tarball_name"'$' "$tarball_basename-SHA-256.txt" | sha256sum -c) \
   || die_with_runtime_error "$PROGRAM_NAME" "Failed to verify the message digest in \`$tarball_basename-SHA-256.txt'."
 rm "$temp_dir/$tarball_basename-SHA-256.txt"

--- a/cmake/install
+++ b/cmake/install
@@ -145,13 +145,13 @@ done
 tarball_basename="cmake-$version"
 tarball_name="$tarball_basename.tar.gz"
 
-(cd "$temp_dir" || exit $?;
+(cd "$temp_dir" || exit $?
  curl -fLsSo "$tarball_name" "https://cmake.org/files/LatestRelease/$tarball_name") \
   || die_with_runtime_error "$PROGRAM_NAME" "Failed to download \`$tarball_name'."
-(cd "$temp_dir" || exit $?;
+(cd "$temp_dir" || exit $?
  curl -fLsSo "$tarball_basename-SHA-256.txt" "https://cmake.org/files/LatestRelease/$tarball_basename-SHA-256.txt") \
   || die_with_runtime_error "$PROGRAM_NAME" "Failed to download \`$tarball_basename-SHA-256.txt'."
-(cd "$temp_dir" || exit $?;
+(cd "$temp_dir" || exit $?
  curl -fLsSo "$tarball_basename-SHA-256.txt.asc" "https://cmake.org/files/LatestRelease/$tarball_basename-SHA-256.txt.asc") \
   || die_with_runtime_error "$PROGRAM_NAME" "Failed to download \`$tarball_basename-SHA-256.txt.asc'."
 
@@ -164,7 +164,7 @@ gpg                                             \
   || die_with_runtime_error "$PROGRAM_NAME" "Failed to verify the signature in \`$tarball_basename-SHA-256.txt.asc'."
 rm "$temp_dir/$tarball_basename-SHA-256.txt.asc"
 
-(cd "$temp_dir" || exit $?;
+(cd "$temp_dir" || exit $?
  grep -E "[[:space:]]$tarball_name"'$' "$tarball_basename-SHA-256.txt" | sha256sum -c) \
   || die_with_runtime_error "$PROGRAM_NAME" "Failed to verify the message digest in \`$tarball_basename-SHA-256.txt'."
 rm "$temp_dir/$tarball_basename-SHA-256.txt"

--- a/gcc/install
+++ b/gcc/install
@@ -172,7 +172,7 @@ rm "$source_dir"/*.tar.*
 build_dir="$temp_dir/build"
 mkdir "$build_dir"
 
-(cd "$build_dir" || exit $?;
+(cd "$build_dir" || exit $?
  "$source_dir/configure"                             \
    --disable-multilib                                \
    --enable-languages=c,c++                          \

--- a/gcc/install
+++ b/gcc/install
@@ -172,7 +172,7 @@ rm "$source_dir"/*.tar.*
 build_dir="$temp_dir/build"
 mkdir "$build_dir"
 
-(cd "$build_dir"
+(cd "$build_dir" || exit $?;
  "$source_dir/configure"                             \
    --disable-multilib                                \
    --enable-languages=c,c++                          \

--- a/icu4c/configure
+++ b/icu4c/configure
@@ -175,6 +175,8 @@ fi
 if [[ $(readlink -m "$build_dir") != $(cd "$temp_dir" >/dev/null && readlink -m "$build_dir") ]]; then
   die_with_user_error "$PROGRAM_NAME" "A relative path \`$build_dir' is specified for \`--build-dir' option, but is expected to be an absolute one."
 fi
+mkdir -p "$build_dir" \
+  || die_with_runtime_error "$PROGRAM_NAME" "Failed to create the build directory \`$build_dir'."
 
 if [[ ${build_type-NOT-DEFINED} == NOT-DEFINED ]]; then
   build_type=release
@@ -309,7 +311,7 @@ fi
 # `runConfigureICU <PLATFORM> VAR=VAL' does not work if `VAL' has a space.
 # Therefore, pass `VAR=VAL' on to ICU4C's configure script via environment
 # variable.
-(cd "$build_dir"
+(cd "$build_dir" || exit $?;
  env                                                  \
    ${env_vars[@]+"${env_vars[@]}"}                    \
    "$source_dir/source/runConfigureICU"               \

--- a/icu4c/configure
+++ b/icu4c/configure
@@ -311,7 +311,7 @@ fi
 # `runConfigureICU <PLATFORM> VAR=VAL' does not work if `VAL' has a space.
 # Therefore, pass `VAR=VAL' on to ICU4C's configure script via environment
 # variable.
-(cd "$build_dir" || exit $?;
+(cd "$build_dir" || exit $?
  env                                                  \
    ${env_vars[@]+"${env_vars[@]}"}                    \
    "$source_dir/source/runConfigureICU"               \

--- a/libbacktrace/install
+++ b/libbacktrace/install
@@ -115,7 +115,7 @@ mkdir -p "$source_dir_prefix" \
 build_dir="$temp_dir/build"
 mkdir "$build_dir"
 
-(cd "$build_dir"
+(cd "$build_dir" || exit $?;
  "$source_dir/configure" --with-pic ${configure_options[@]+"${configure_options[@]}"}) \
   || die_with_runtime_error "$PROGRAM_NAME" "Failed to \`configure' libbacktrace."
 

--- a/libbacktrace/install
+++ b/libbacktrace/install
@@ -115,7 +115,7 @@ mkdir -p "$source_dir_prefix" \
 build_dir="$temp_dir/build"
 mkdir "$build_dir"
 
-(cd "$build_dir" || exit $?;
+(cd "$build_dir" || exit $?
  "$source_dir/configure" --with-pic ${configure_options[@]+"${configure_options[@]}"}) \
   || die_with_runtime_error "$PROGRAM_NAME" "Failed to \`configure' libbacktrace."
 


### PR DESCRIPTION
- `gcc/install`: Tweak.
- `cmake/install`: Likewise.
- `libbacktrace/install`: Likewise.
- `icu4c/configure`: Fix to create the build directory if it does not exist.
